### PR TITLE
Improve API compatibility for raffle listing

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,134 @@
 ﻿// API configuration and types for the solidarity raffle application
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
+type UnknownRecord = Record<string, unknown>;
+
+function normalizeString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  return String(value);
+}
+
+function normalizeNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+
+  return fallback;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeString(item)).filter(Boolean);
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    return [value];
+  }
+
+  return [];
+}
+
+function normalizeRaffle(data: UnknownRecord | null | undefined): Raffle | null {
+  if (!data) {
+    return null;
+  }
+
+  const id = normalizeNumber(data.id, -1);
+  const slug = normalizeString(data.slug);
+
+  if (id < 0 || !slug) {
+    return null;
+  }
+
+  return {
+    id,
+    slug,
+    title: normalizeString(data.title),
+    description: normalizeString(data.description),
+    rules: (data.rules as string | null) ?? null,
+    prize_image:
+      (typeof data.prize_image === "string" && data.prize_image.trim() !== ""
+        ? data.prize_image
+        : typeof data.prize_image_url === "string"
+          ? data.prize_image_url
+          : typeof data.image === "string"
+            ? data.image
+            : null) ?? null,
+    prize_images: normalizeStringArray(
+      data.prize_images ?? data.prize_gallery ?? data.images ?? null,
+    ),
+    ticket_price: normalizeNumber(data.ticket_price),
+    total_tickets: normalizeNumber(data.total_tickets),
+    sold_tickets: normalizeNumber(data.sold_tickets),
+    draw_date: (data.draw_date as string | null) ?? null,
+    status: (data.status as Raffle["status"]) ?? "active",
+    created_at: (data.created_at as string | null) ?? null,
+    updated_at: (data.updated_at as string | null) ?? null,
+  };
+}
+
+function extractCollection(payload: unknown): Raffle[] {
+  if (!payload) {
+    return [];
+  }
+
+  if (Array.isArray(payload)) {
+    return payload
+      .map((item) => normalizeRaffle((item ?? null) as UnknownRecord))
+      .filter((item): item is Raffle => Boolean(item));
+  }
+
+  const record = payload as UnknownRecord;
+
+  if (Array.isArray(record.data)) {
+    return extractCollection(record.data);
+  }
+
+  if (record.data && typeof record.data === "object") {
+    const inner = record.data as UnknownRecord;
+
+    if (Array.isArray(inner.data)) {
+      return extractCollection(inner.data);
+    }
+  }
+
+  if (Array.isArray(record.raffles)) {
+    return extractCollection(record.raffles);
+  }
+
+  return [];
+}
+
+function extractResource(payload: unknown): Raffle | null {
+  if (!payload) {
+    return null;
+  }
+
+  if (!Array.isArray(payload) && typeof payload === "object") {
+    const record = payload as UnknownRecord;
+
+    if (record.data && typeof record.data === "object" && !Array.isArray(record.data)) {
+      const normalized = normalizeRaffle(record.data as UnknownRecord);
+      if (normalized) {
+        return normalized;
+      }
+    }
+
+    const normalized = normalizeRaffle(record as UnknownRecord);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
 export interface Raffle {
   id: number;
   slug: string;
@@ -76,14 +204,20 @@ export async function fetchActiveRaffles(): Promise<Raffle[]> {
       method: "GET",
     });
 
-    const payload = await safeParseJson<ApiCollection<Raffle>>(response);
+    const payload = await safeParseJson<unknown>(response);
 
     if (!response.ok || !payload) {
       console.error("Falha ao buscar sorteios:", payload);
       return [];
     }
 
-    return Array.isArray(payload.data) ? payload.data : [];
+    const raffles = extractCollection(payload);
+
+    if (!raffles.length) {
+      console.error("Nenhum sorteio válido retornado pela API:", payload);
+    }
+
+    return raffles;
   } catch (error) {
     console.error("Erro ao buscar sorteios:", error);
     return [];
@@ -97,14 +231,20 @@ export async function fetchRaffleBySlug(slug: string): Promise<Raffle | null> {
       method: "GET",
     });
 
-    const payload = await safeParseJson<ApiResource<Raffle>>(response);
+    const payload = await safeParseJson<unknown>(response);
 
     if (!response.ok || !payload) {
       console.error("Falha ao buscar sorteio:", payload);
       return null;
     }
 
-    return payload.data ?? null;
+    const raffle = extractResource(payload);
+
+    if (!raffle) {
+      console.error("Resposta de sorteio inválida:", payload);
+    }
+
+    return raffle;
   } catch (error) {
     console.error("Erro ao buscar sorteio:", error);
     return null;


### PR DESCRIPTION
## Summary
- add response normalization helpers to consume different Laravel API payload shapes
- normalize raffle fields before usage, including fallback keys and type coercion
- improve error logging when the API does not return valid raffles

## Testing
- `npm run lint` *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d562415d7083238ef0da6447754eff